### PR TITLE
refactor(deno): deno.run command has been deprecated

### DIFF
--- a/src/fzf.ts
+++ b/src/fzf.ts
@@ -27,60 +27,57 @@ export const fzf = async ({
   cycle,
   printQuery,
 }: FzfOptions, input?: string) => {
-  const cmd = ["fzf"];
-
   // default options
-  cmd.push("--ansi");
-  cmd.push("--reverse");
-  cmd.push("--border=none");
+  const args = ["--ansi", "--reverse", "--border=none"];
 
   if (delimiter !== undefined) {
-    cmd.push("--delimiter", delimiter);
+    args.push("--delimiter", delimiter);
   }
   if (withNth !== undefined) {
-    cmd.push("--with-nth", `${withNth}`);
+    args.push("--with-nth", `${withNth}`);
   }
   if (height !== undefined) {
-    cmd.push("--height", `${height}`);
+    args.push("--height", `${height}`);
   }
   if (bind !== undefined) {
-    cmd.push("--bind", bind);
+    args.push("--bind", bind);
   }
   if (preview !== undefined) {
-    cmd.push("--preview", preview);
+    args.push("--preview", preview);
   }
   if (previewWindow !== undefined) {
-    cmd.push("--preview-window", previewWindow);
+    args.push("--preview-window", previewWindow);
   }
   if (header !== undefined) {
-    cmd.push("--header", header);
+    args.push("--header", header);
   }
   if (prompt !== undefined) {
-    cmd.push("--prompt", prompt);
+    args.push("--prompt", prompt);
   }
   if (cycle !== undefined) {
-    cmd.push("--cycle");
+    args.push("--cycle");
   }
   if (printQuery === true) {
-    cmd.push("--print-query");
+    args.push("--print-query");
   }
 
   const env = {
     FZF_DEFAULT_OPTS: "",
   };
 
-  const p = Deno.run({
-    cmd,
+  const child = new Deno.Command("fzf", {
+    args,
     env,
     stdin: "piped",
     stdout: "piped",
-  });
+  }).spawn();
 
-  p.stdin?.write(new TextEncoder().encode(input ?? "\n"));
-  p.stdin?.close();
+  const writer = child.stdin.getWriter();
+  writer.write(new TextEncoder().encode(input ?? "\n"));
+  writer.close();
 
-  const output = new TextDecoder().decode(await p.output());
-  const { success, code } = await p.status();
+  const output = new TextDecoder().decode((await child.output()).stdout);
+  const { success, code } = await child.status;
 
   return { success, code, output };
 };

--- a/src/fzf.ts
+++ b/src/fzf.ts
@@ -76,8 +76,8 @@ export const fzf = async ({
   writer.write(new TextEncoder().encode(input ?? "\n"));
   writer.close();
 
-  const output = new TextDecoder().decode((await child.output()).stdout);
-  const { success, code } = await child.status;
+  const { success, code, stdout } = await child.output();
+  const output = new TextDecoder().decode(stdout);
 
   return { success, code, output };
 };

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,9 +4,7 @@ export const isInsideRepository = async () => {
     stderr: "piped",
   });
 
-  const child = command.spawn();
-
-  const { success } = await child.status;
+  const { success } = await command.output();
   return success;
 };
 
@@ -15,9 +13,7 @@ export const isClean = async () => {
     args: ["diff", "--cached", "--quiet"],
   });
 
-  const child = command.spawn();
-
-  const { success } = await child.status;
+  const { success } = await command.output();
   return success;
 };
 
@@ -26,8 +22,6 @@ export const commit = async (message: string, args: string[] = []) => {
     args: ["commit", "-m", message, ...args],
   });
 
-  const child = command.spawn();
-
-  const { success } = await child.status;
+  const { success } = await command.output();
   return success;
 };

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,27 +1,33 @@
 export const isInsideRepository = async () => {
-  const p = Deno.run({
-    cmd: ["git", "rev-parse"],
+  const command = new Deno.Command("git", {
+    args: ["rev-parse"],
     stderr: "piped",
   });
 
-  const { success } = await p.status();
+  const child = command.spawn();
+
+  const { success } = await child.status;
   return success;
 };
 
 export const isClean = async () => {
-  const p = Deno.run({
-    cmd: ["git", "diff", "--cached", "--quiet"],
+  const command = new Deno.Command("git", {
+    args: ["diff", "--cached", "--quiet"],
   });
 
-  const { success } = await p.status();
+  const child = command.spawn();
+
+  const { success } = await child.status;
   return success;
 };
 
 export const commit = async (message: string, args: string[] = []) => {
-  const p = Deno.run({
-    cmd: ["git", "commit", "-m", message, ...args],
+  const command = new Deno.Command("git", {
+    args: ["commit", "-m", message, ...args],
   });
 
-  const { success } = await p.status();
+  const child = command.spawn();
+
+  const { success } = await child.status;
   return success;
 };


### PR DESCRIPTION
This refactors the deprecated `Deno.run` command to `Deno.Command`.

See https://deno.land/api@v1.40.2?s=Deno.run